### PR TITLE
Add cross-platform FinOps CLI scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-# finazops
+# FinOps CLI Toolkit
+
+This repository contains a simple cross-platform FinOps command line toolkit written in Bash and PowerShell. The scripts simulate detection of cloud waste, budget checks, and cost‑saving recommendations using local mock data. Output is styled with ANSI colors and Unicode tables similar to the screenshot referenced in the project description.
+
+## Scripts
+
+- `detect-waste.sh` / `detect-waste.ps1` – find stopped EC2 instances, detached EIPs, and unattached EBS volumes and show estimated monthly waste.
+- `check-budgets.sh` / `check-budgets.ps1` – check mock budgets for multiple profiles and indicate if they are under or over budget.
+- `generate-recommendations.sh` / `generate-recommendations.ps1` – display recommendations based on detected waste.
+
+The scripts rely only on Bash (for Linux/macOS) or PowerShell (for Windows). No cloud APIs or additional tools are required.
+
+## Running on Replit or Linux/macOS
+
+```bash
+bash detect-waste.sh
+bash check-budgets.sh
+bash generate-recommendations.sh
+```
+
+Ensure the scripts have execute permissions:
+
+```bash
+chmod +x *.sh
+```
+
+## Running on Windows PowerShell
+
+In a PowerShell terminal run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File detect-waste.ps1
+powershell -ExecutionPolicy Bypass -File check-budgets.ps1
+powershell -ExecutionPolicy Bypass -File generate-recommendations.ps1
+```
+
+These commands will output colorized tables summarizing waste, budgets, and recommended actions using mock data.
+

--- a/check-budgets.ps1
+++ b/check-budgets.ps1
@@ -1,0 +1,24 @@
+# Check budgets using mock data
+$red="`e[1;31m"
+$green="`e[1;32m"
+$reset="`e[0m"
+
+$budgets=@(
+  @{Profile='profile-02'; Limit=100; Actual=90}
+  @{Profile='profile-03'; Limit=120; Actual=130}
+)
+
+Write-Host ""
+Write-Host "┌──┬──┬──┐"
+Write-Host "│ Profile    │ Limit     │ Actual    │"
+Write-Host "├──┼──┼──┤"
+foreach($b in $budgets){
+  if($b.Actual -gt $b.Limit){
+    $color=$red
+  }else{
+    $color=$green
+  }
+  Write-Host ("│ {0,-10} │ {1,6}    │ {2,6}    │" -f $b.Profile, $b.Limit, $b.Actual) -ForegroundColor ($color.Trim('`e[0m'))
+}
+Write-Host "└──┴──┴──┘"
+

--- a/check-budgets.sh
+++ b/check-budgets.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Check budgets for different profiles using mock data
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+# Mock data: profile:limit:actual
+BUDGETS=(
+  "profile-02:100:90"
+  "profile-03:120:130"
+)
+
+printf "\n\u250C\u2500\u252C\u2500\u252C\u2500\u2510\n"
+printf "\u2502 %-10s \u2502 %-10s \u2502 %-10s \u2502\n" "Profile" "Limit" "Actual"
+printf "\u251C\u2500\u253C\u2500\u253C\u2500\u2524\n"
+
+for item in "${BUDGETS[@]}"; do
+  IFS=":" read -r profile limit actual <<< "$item"
+  if (( actual > limit )); then
+    color=$RED
+  else
+    color=$GREEN
+  fi
+  printf "\u2502 %-10s \u2502 %4d       \u2502 %b%4d%b     \u2502\n" "$profile" "$limit" "$color" "$actual" "$RESET"
+done
+
+printf "\u2514\u2500\u2534\u2500\u2534\u2500\u2518\n"
+

--- a/detect-waste.ps1
+++ b/detect-waste.ps1
@@ -1,0 +1,49 @@
+# Detect cloud waste using mock data and display summary
+$red="`e[1;31m"
+$green="`e[1;32m"
+$yellow="`e[1;33m"
+$reset="`e[0m"
+
+$instances=@(
+  @{Id='i-001'; State='stopped'; Cost=10}
+  @{Id='i-002'; State='running'; Cost=20}
+  @{Id='i-003'; State='stopped'; Cost=15}
+)
+$eips=@(
+  @{Id='eipalloc-001'; Attached=$false; Cost=3}
+  @{Id='eipalloc-002'; Attached=$true; Cost=0}
+)
+$volumes=@(
+  @{Id='vol-001'; Attached=$false; Cost=5}
+  @{Id='vol-002'; Attached=$true; Cost=0}
+)
+
+Write-Host ""
+Write-Host "┌──┬──┬──┐"
+Write-Host "│ Resource ID │ Status   │ Monthly $ │"
+Write-Host "├──┼──┼──┤"
+
+$total=0
+foreach($i in $instances){
+  if($i.State -eq 'stopped'){
+    Write-Host ("│ {0,-12} │ {1,-8} │ {2,4}     │" -f $i.Id, $i.State, $i.Cost) -NoNewline
+    Write-Host "" -ForegroundColor Red
+    $total+=$i.Cost
+  }
+}
+foreach($e in $eips){
+  if(-not $e.Attached){
+    Write-Host ("│ {0,-12} │ detached │ {1,4}     │" -f $e.Id, $e.Cost) -ForegroundColor Yellow
+    $total+=$e.Cost
+  }
+}
+foreach($v in $volumes){
+  if(-not $v.Attached){
+    Write-Host ("│ {0,-12} │ unattached │ {1,4}   │" -f $v.Id, $v.Cost) -ForegroundColor Yellow
+    $total+=$v.Cost
+  }
+}
+Write-Host "└──┴──┴──┘"
+Write-Host ""
+Write-Host ("Estimated monthly waste: $${0}" -f $total) -ForegroundColor Red
+

--- a/detect-waste.sh
+++ b/detect-waste.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Detect cloud waste using mock data and display summary
+
+# ANSI colors
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+# Mock data arrays: id:status:monthly_cost
+EC2_INSTANCES=(
+  "i-001:stopped:10"
+  "i-002:running:20"
+  "i-003:stopped:15"
+)
+
+EIPS=(
+  "eipalloc-001:detached:3"
+  "eipalloc-002:attached:0"
+)
+
+EBS_VOLUMES=(
+  "vol-001:unattached:5"
+  "vol-002:attached:0"
+)
+
+# Print table header
+printf "\n\u250C\u2500\u252C\u2500\u252C\u2500\u2510\n"
+printf "\u2502 %-12s \u2502 %-8s \u2502 %-11s \u2502\n" "Resource" "Status" "Monthly $"
+printf "\u251C\u2500\u253C\u2500\u253C\u2500\u2524\n"
+
+total=0
+
+print_row() {
+  local id=$1
+  local status=$2
+  local cost=$3
+  local color=$4
+  printf "\u2502 %-12s \u2502 %b%-8s%b \u2502 %4d %7s \u2502\n" "$id" "$color" "$status" "$RESET" "$cost" ""
+}
+
+for item in "${EC2_INSTANCES[@]}"; do
+  IFS=":" read -r id state cost <<< "$item"
+  if [[ $state == "stopped" ]]; then
+    print_row "$id" "$state" "$cost" "$RED"
+    total=$((total + cost))
+  fi
+done
+for item in "${EIPS[@]}"; do
+  IFS=":" read -r id status cost <<< "$item"
+  if [[ $status == "detached" ]]; then
+    print_row "$id" "$status" "$cost" "$YELLOW"
+    total=$((total + cost))
+  fi
+done
+for item in "${EBS_VOLUMES[@]}"; do
+  IFS=":" read -r id status cost <<< "$item"
+  if [[ $status == "unattached" ]]; then
+    print_row "$id" "$status" "$cost" "$YELLOW"
+    total=$((total + cost))
+  fi
+done
+
+printf "\u2514\u2500\u2534\u2500\u2534\u2500\u2518\n"
+
+printf "\nEstimated monthly waste: %b$%d%b\n" "$RED" "$total" "$RESET"
+

--- a/generate-recommendations.ps1
+++ b/generate-recommendations.ps1
@@ -1,0 +1,32 @@
+# Generate cost-saving recommendations
+$yellow="`e[1;33m"
+$reset="`e[0m"
+
+$instances=@(
+  @{Id='i-001'; State='stopped'; Cost=10}
+  @{Id='i-002'; State='running'; Cost=20}
+  @{Id='i-003'; State='stopped'; Cost=15}
+)
+$eips=@(
+  @{Id='eipalloc-001'; Attached=$false; Cost=3}
+  @{Id='eipalloc-002'; Attached=$true; Cost=0}
+)
+$volumes=@(
+  @{Id='vol-001'; Attached=$false; Cost=5}
+  @{Id='vol-002'; Attached=$true; Cost=0}
+)
+
+$recs=@()
+foreach($i in $instances){ if($i.State -eq 'stopped'){ $recs+= "Terminate $($i.Id) to save $${$i.Cost}/mo" } }
+foreach($e in $eips){ if(-not $e.Attached){ $recs+= "Release $($e.Id) to save $${$e.Cost}/mo" } }
+foreach($v in $volumes){ if(-not $v.Attached){ $recs+= "Delete $($v.Id) to save $${$v.Cost}/mo" } }
+
+Write-Host ""
+Write-Host "┌──┬──┐"
+Write-Host "│ Recommendation                           │"
+Write-Host "├──┼──┤"
+foreach($r in $recs){
+  Write-Host ("│ {0,-40} │" -f $r) -ForegroundColor Yellow
+}
+Write-Host "└──┴──┘"
+

--- a/generate-recommendations.sh
+++ b/generate-recommendations.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Generate cost-saving recommendations from mock audit
+
+RED='\033[1;31m'
+GREEN='\033[1;32m'
+YELLOW='\033[1;33m'
+RESET='\033[0m'
+
+EC2_INSTANCES=(
+  "i-001:stopped:10"
+  "i-002:running:20"
+  "i-003:stopped:15"
+)
+
+EIPS=(
+  "eipalloc-001:detached:3"
+  "eipalloc-002:attached:0"
+)
+
+EBS_VOLUMES=(
+  "vol-001:unattached:5"
+  "vol-002:attached:0"
+)
+
+RECOMMENDATIONS=()
+for item in "${EC2_INSTANCES[@]}"; do
+  IFS=":" read -r id state cost <<< "$item"
+  if [[ $state == "stopped" ]]; then
+    RECOMMENDATIONS+=("Terminate $id to save \$${cost}/mo")
+  fi
+done
+for item in "${EIPS[@]}"; do
+  IFS=":" read -r id status cost <<< "$item"
+  if [[ $status == "detached" ]]; then
+    RECOMMENDATIONS+=("Release $id to save \$${cost}/mo")
+  fi
+done
+for item in "${EBS_VOLUMES[@]}"; do
+  IFS=":" read -r id status cost <<< "$item"
+  if [[ $status == "unattached" ]]; then
+    RECOMMENDATIONS+=("Delete $id to save \$${cost}/mo")
+  fi
+done
+
+printf "\n\u250C\u2500\u252C\u2500\u2510\n"
+printf "\u2502 %-40s \u2502\n" "Recommendation"
+printf "\u251C\u2500\u253C\u2500\u2524\n"
+for rec in "${RECOMMENDATIONS[@]}"; do
+  printf "\u2502 %-40s \u2502\n" "$rec"
+done
+printf "\u2514\u2500\u2534\u2500\u2518\n"
+


### PR DESCRIPTION
## Summary
- create Bash and PowerShell scripts to simulate waste detection, budget checks and recommendations
- style output with ANSI color and Unicode tables
- document usage in a new README

## Testing
- `bash -n detect-waste.sh`
- `bash -n check-budgets.sh`
- `bash -n generate-recommendations.sh`
- `./detect-waste.sh`
- `./check-budgets.sh`
- `./generate-recommendations.sh`

Codex couldn't run PowerShell commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_68533f929bf883239082161daafb4a69