### PR TITLE
Fix run-app badge link

### DIFF
--- a/.github/workflows/run-app.yml
+++ b/.github/workflows/run-app.yml
@@ -1,0 +1,23 @@
+name: Run FinOps App
+
+on:
+  workflow_dispatch:
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          pip install --quiet rich fpdf
+      - name: Run FinOps CLI
+        run: |
+          python3 finops_cli.py --trend
+          bash check-budgets.sh
+          bash detect-waste.sh
+          bash generate-recommendations.sh

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ This repository contains a simple cross-platform FinOps command line toolkit wri
 
 The scripts rely only on Bash (for Linux/macOS) or PowerShell (for Windows). No cloud APIs or additional tools are required.
 
+## Run on GitHub
+
+You can execute the toolkit directly in a GitHub Actions runner using the `run-app` workflow. Click the badge below, then select **Run workflow** on the Actions page.
+
+[![Run FinOps Toolkit](https://github.com/cloudcwfranck/finazops/actions/workflows/run-app.yml/badge.svg?branch=main)](https://github.com/cloudcwfranck/finazops/actions/workflows/run-app.yml)
+
 ## Running on Replit or Linux/macOS
 
 ```bash


### PR DESCRIPTION
## Summary
- fix README run-app badge to specify `branch=main`
- ensure run-app workflow uses `python3`

## Testing
- `python3 finops_cli.py --help` *(fails: Required dependency missing: No module named 'rich')*
- `pip install rich fpdf` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685344ef95608323ba2408c07b007330