### PR TITLE
Improve GitHub Actions run output

### DIFF
--- a/.github/workflows/run-app.yml
+++ b/.github/workflows/run-app.yml
@@ -21,7 +21,10 @@ jobs:
 
       - name: Run FinOps CLI and scripts
         run: |
-          python3 finops_cli.py --trend
-          bash check-budgets.sh
-          bash detect-waste.sh
-          bash generate-recommendations.sh
+          set -e
+          tmp=$(mktemp)
+          python3 finops_cli.py --trend | tee -a "$tmp"
+          bash check-budgets.sh | tee -a "$tmp"
+          bash detect-waste.sh | tee -a "$tmp"
+          bash generate-recommendations.sh | tee -a "$tmp"
+          cat "$tmp" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ The scripts rely only on Bash (for Linux/macOS) or PowerShell (for Windows). No 
 ## Run on GitHub
 
 [![Run FinOps Toolkit](https://github.com/cloudcwfranck/finazops/actions/workflows/run-app.yml/badge.svg?branch=main)](https://github.com/cloudcwfranck/finazops/actions/workflows/run-app.yml)
-=======
-You can execute the toolkit directly in a GitHub Actions runner using the
-`run-app` workflow. Click the badge below and then select **Run workflow** on the
-Actions page to start a one-off run.
+
+Execute the toolkit in a GitHub Actions runner using the `run-app` workflow.
+Click the badge above, choose **Run workflow**, and once the job completes open
+the run and view the output in the **Summary** tab directly in your browser.
 
 ## Running on Replit or Linux/macOS
 


### PR DESCRIPTION
## Summary
- pipe script output to the GitHub Actions summary
- clarify README instructions about viewing workflow results

## Testing
- `python3 finops_cli.py --help` *(fails: `Required dependency missing: No module named 'rich'`)*
- `bash detect-waste.sh`
- `bash check-budgets.sh`
- `bash generate-recommendations.sh`
- `pip install rich fpdf` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68534bafc9b48323987472b013a210e7