### PR TITLE
Port FinOps toolkit to Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This repository contains a simple cross-platform FinOps command line toolkit wri
 
 ## Scripts
 
-- `detect-waste.sh` / `detect-waste.ps1` – find stopped EC2 instances, detached EIPs, and unattached EBS volumes and show estimated monthly waste.
-- `check-budgets.sh` / `check-budgets.ps1` – check mock budgets for multiple profiles and indicate if they are under or over budget.
+- `detect-waste.sh` / `detect-waste.ps1` – find stopped Azure VMs, unassociated public IPs, and unattached managed disks and show estimated monthly waste.
+- `check-budgets.sh` / `check-budgets.ps1` – check mock budgets for multiple subscriptions and indicate if they are under or over budget.
 - `generate-recommendations.sh` / `generate-recommendations.ps1` – display recommendations based on detected waste.
 
 The scripts rely only on Bash (for Linux/macOS) or PowerShell (for Windows). No cloud APIs or additional tools are required.
@@ -47,7 +47,7 @@ These commands will output colorized tables summarizing waste, budgets, and reco
 
 ## Python FinOps CLI
 
-A new `finops_cli.py` script adds enhanced features such as cost analysis by time period, cost trends, profile management and export options. It uses the [Rich](https://pypi.org/project/rich/) library for a pleasant terminal UI.
+A new `finops_cli.py` script adds enhanced features such as cost analysis by time period, cost trends, subscription management and export options. It uses the [Rich](https://pypi.org/project/rich/) library for a pleasant terminal UI.
 
 Run the script with Python 3:
 

--- a/check-budgets.ps1
+++ b/check-budgets.ps1
@@ -4,13 +4,13 @@ $green="`e[1;32m"
 $reset="`e[0m"
 
 $budgets=@(
-  @{Profile='profile-02'; Limit=100; Actual=90}
-  @{Profile='profile-03'; Limit=120; Actual=130}
+  @{Subscription='sub-01'; Limit=100; Actual=90}
+  @{Subscription='sub-02'; Limit=120; Actual=130}
 )
 
 Write-Host ""
 Write-Host "┌──┬──┬──┐"
-Write-Host "│ Profile    │ Limit     │ Actual    │"
+Write-Host "│ Subscription │ Limit     │ Actual    │"
 Write-Host "├──┼──┼──┤"
 foreach($b in $budgets){
   if($b.Actual -gt $b.Limit){
@@ -18,7 +18,7 @@ foreach($b in $budgets){
   }else{
     $color=$green
   }
-  Write-Host ("│ {0,-10} │ {1,6}    │ {2,6}    │" -f $b.Profile, $b.Limit, $b.Actual) -ForegroundColor ($color.Trim('`e[0m'))
+  Write-Host ("│ {0,-12} │ {1,6}    │ {2,6}    │" -f $b.Subscription, $b.Limit, $b.Actual) -ForegroundColor ($color.Trim('`e[0m'))
 }
 Write-Host "└──┴──┴──┘"
 

--- a/check-budgets.sh
+++ b/check-budgets.sh
@@ -1,29 +1,29 @@
 #!/usr/bin/env bash
-# Check budgets for different profiles using mock data
+# Check budgets for different subscriptions using mock data
 
 RED='\033[1;31m'
 GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-# Mock data: profile:limit:actual
+# Mock data: subscription:limit:actual
 BUDGETS=(
-  "profile-02:100:90"
-  "profile-03:120:130"
+  "sub-01:100:90"
+  "sub-02:120:130"
 )
 
 printf "\n\u250C\u2500\u252C\u2500\u252C\u2500\u2510\n"
-printf "\u2502 %-10s \u2502 %-10s \u2502 %-10s \u2502\n" "Profile" "Limit" "Actual"
+printf "\u2502 %-10s \u2502 %-10s \u2502 %-10s \u2502\n" "Subscription" "Limit" "Actual"
 printf "\u251C\u2500\u253C\u2500\u253C\u2500\u2524\n"
 
 for item in "${BUDGETS[@]}"; do
-  IFS=":" read -r profile limit actual <<< "$item"
+  IFS=":" read -r subscription limit actual <<< "$item"
   if (( actual > limit )); then
     color=$RED
   else
     color=$GREEN
   fi
-  printf "\u2502 %-10s \u2502 %4d       \u2502 %b%4d%b     \u2502\n" "$profile" "$limit" "$color" "$actual" "$RESET"
+  printf "\u2502 %-10s \u2502 %4d       \u2502 %b%4d%b     \u2502\n" "$subscription" "$limit" "$color" "$actual" "$RESET"
 done
 
 printf "\u2514\u2500\u2534\u2500\u2534\u2500\u2518\n"

--- a/detect-waste.ps1
+++ b/detect-waste.ps1
@@ -4,18 +4,18 @@ $green="`e[1;32m"
 $yellow="`e[1;33m"
 $reset="`e[0m"
 
-$instances=@(
-  @{Id='i-001'; State='stopped'; Cost=10}
-  @{Id='i-002'; State='running'; Cost=20}
-  @{Id='i-003'; State='stopped'; Cost=15}
+$vms=@(
+  @{Id='vm-001'; State='stopped'; Cost=10}
+  @{Id='vm-002'; State='running'; Cost=20}
+  @{Id='vm-003'; State='stopped'; Cost=15}
 )
-$eips=@(
-  @{Id='eipalloc-001'; Attached=$false; Cost=3}
-  @{Id='eipalloc-002'; Attached=$true; Cost=0}
+$publicIps=@(
+  @{Id='pip-001'; Associated=$false; Cost=3}
+  @{Id='pip-002'; Associated=$true; Cost=0}
 )
-$volumes=@(
-  @{Id='vol-001'; Attached=$false; Cost=5}
-  @{Id='vol-002'; Attached=$true; Cost=0}
+$disks=@(
+  @{Id='disk-001'; Attached=$false; Cost=5}
+  @{Id='disk-002'; Attached=$true; Cost=0}
 )
 
 Write-Host ""
@@ -24,23 +24,23 @@ Write-Host "│ Resource ID │ Status   │ Monthly $ │"
 Write-Host "├──┼──┼──┤"
 
 $total=0
-foreach($i in $instances){
+foreach($i in $vms){
   if($i.State -eq 'stopped'){
     Write-Host ("│ {0,-12} │ {1,-8} │ {2,4}     │" -f $i.Id, $i.State, $i.Cost) -NoNewline
     Write-Host "" -ForegroundColor Red
     $total+=$i.Cost
   }
 }
-foreach($e in $eips){
-  if(-not $e.Attached){
-    Write-Host ("│ {0,-12} │ detached │ {1,4}     │" -f $e.Id, $e.Cost) -ForegroundColor Yellow
-    $total+=$e.Cost
+$publicIps | ForEach-Object {
+  if(-not $_.Associated){
+    Write-Host ("│ {0,-12} │ unassociated │ {1,4}     │" -f $_.Id, $_.Cost) -ForegroundColor Yellow
+    $total+=$_.Cost
   }
 }
-foreach($v in $volumes){
-  if(-not $v.Attached){
-    Write-Host ("│ {0,-12} │ unattached │ {1,4}   │" -f $v.Id, $v.Cost) -ForegroundColor Yellow
-    $total+=$v.Cost
+$disks | ForEach-Object {
+  if(-not $_.Attached){
+    Write-Host ("│ {0,-12} │ unattached │ {1,4}   │" -f $_.Id, $_.Cost) -ForegroundColor Yellow
+    $total+=$_.Cost
   }
 }
 Write-Host "└──┴──┴──┘"

--- a/detect-waste.sh
+++ b/detect-waste.sh
@@ -8,20 +8,20 @@ YELLOW='\033[1;33m'
 RESET='\033[0m'
 
 # Mock data arrays: id:status:monthly_cost
-EC2_INSTANCES=(
-  "i-001:stopped:10"
-  "i-002:running:20"
-  "i-003:stopped:15"
+VMS=(
+  "vm-001:stopped:10"
+  "vm-002:running:20"
+  "vm-003:stopped:15"
 )
 
-EIPS=(
-  "eipalloc-001:detached:3"
-  "eipalloc-002:attached:0"
+PUBLIC_IPS=(
+  "pip-001:unassociated:3"
+  "pip-002:associated:0"
 )
 
-EBS_VOLUMES=(
-  "vol-001:unattached:5"
-  "vol-002:attached:0"
+MANAGED_DISKS=(
+  "disk-001:unattached:5"
+  "disk-002:attached:0"
 )
 
 # Print table header
@@ -39,21 +39,21 @@ print_row() {
   printf "\u2502 %-12s \u2502 %b%-8s%b \u2502 %4d %7s \u2502\n" "$id" "$color" "$status" "$RESET" "$cost" ""
 }
 
-for item in "${EC2_INSTANCES[@]}"; do
+for item in "${VMS[@]}"; do
   IFS=":" read -r id state cost <<< "$item"
   if [[ $state == "stopped" ]]; then
     print_row "$id" "$state" "$cost" "$RED"
     total=$((total + cost))
   fi
 done
-for item in "${EIPS[@]}"; do
+for item in "${PUBLIC_IPS[@]}"; do
   IFS=":" read -r id status cost <<< "$item"
-  if [[ $status == "detached" ]]; then
+  if [[ $status == "unassociated" ]]; then
     print_row "$id" "$status" "$cost" "$YELLOW"
     total=$((total + cost))
   fi
 done
-for item in "${EBS_VOLUMES[@]}"; do
+for item in "${MANAGED_DISKS[@]}"; do
   IFS=":" read -r id status cost <<< "$item"
   if [[ $status == "unattached" ]]; then
     print_row "$id" "$status" "$cost" "$YELLOW"

--- a/generate-recommendations.ps1
+++ b/generate-recommendations.ps1
@@ -2,24 +2,24 @@
 $yellow="`e[1;33m"
 $reset="`e[0m"
 
-$instances=@(
-  @{Id='i-001'; State='stopped'; Cost=10}
-  @{Id='i-002'; State='running'; Cost=20}
-  @{Id='i-003'; State='stopped'; Cost=15}
+$vms=@(
+  @{Id='vm-001'; State='stopped'; Cost=10}
+  @{Id='vm-002'; State='running'; Cost=20}
+  @{Id='vm-003'; State='stopped'; Cost=15}
 )
-$eips=@(
-  @{Id='eipalloc-001'; Attached=$false; Cost=3}
-  @{Id='eipalloc-002'; Attached=$true; Cost=0}
+$publicIps=@(
+  @{Id='pip-001'; Associated=$false; Cost=3}
+  @{Id='pip-002'; Associated=$true; Cost=0}
 )
-$volumes=@(
-  @{Id='vol-001'; Attached=$false; Cost=5}
-  @{Id='vol-002'; Attached=$true; Cost=0}
+$disks=@(
+  @{Id='disk-001'; Attached=$false; Cost=5}
+  @{Id='disk-002'; Attached=$true; Cost=0}
 )
 
 $recs=@()
-foreach($i in $instances){ if($i.State -eq 'stopped'){ $recs+= "Terminate $($i.Id) to save $${$i.Cost}/mo" } }
-foreach($e in $eips){ if(-not $e.Attached){ $recs+= "Release $($e.Id) to save $${$e.Cost}/mo" } }
-foreach($v in $volumes){ if(-not $v.Attached){ $recs+= "Delete $($v.Id) to save $${$v.Cost}/mo" } }
+foreach($i in $vms){ if($i.State -eq 'stopped'){ $recs+= "Terminate $($i.Id) to save $${$i.Cost}/mo" } }
+foreach($e in $publicIps){ if(-not $e.Associated){ $recs+= "Release $($e.Id) to save $${$e.Cost}/mo" } }
+foreach($v in $disks){ if(-not $v.Attached){ $recs+= "Delete $($v.Id) to save $${$v.Cost}/mo" } }
 
 Write-Host ""
 Write-Host "┌──┬──┐"

--- a/generate-recommendations.sh
+++ b/generate-recommendations.sh
@@ -6,36 +6,36 @@ GREEN='\033[1;32m'
 YELLOW='\033[1;33m'
 RESET='\033[0m'
 
-EC2_INSTANCES=(
-  "i-001:stopped:10"
-  "i-002:running:20"
-  "i-003:stopped:15"
+VMS=(
+  "vm-001:stopped:10"
+  "vm-002:running:20"
+  "vm-003:stopped:15"
 )
 
-EIPS=(
-  "eipalloc-001:detached:3"
-  "eipalloc-002:attached:0"
+PUBLIC_IPS=(
+  "pip-001:unassociated:3"
+  "pip-002:associated:0"
 )
 
-EBS_VOLUMES=(
-  "vol-001:unattached:5"
-  "vol-002:attached:0"
+MANAGED_DISKS=(
+  "disk-001:unattached:5"
+  "disk-002:attached:0"
 )
 
 RECOMMENDATIONS=()
-for item in "${EC2_INSTANCES[@]}"; do
+for item in "${VMS[@]}"; do
   IFS=":" read -r id state cost <<< "$item"
   if [[ $state == "stopped" ]]; then
     RECOMMENDATIONS+=("Terminate $id to save \$${cost}/mo")
   fi
 done
-for item in "${EIPS[@]}"; do
+for item in "${PUBLIC_IPS[@]}"; do
   IFS=":" read -r id status cost <<< "$item"
-  if [[ $status == "detached" ]]; then
+  if [[ $status == "unassociated" ]]; then
     RECOMMENDATIONS+=("Release $id to save \$${cost}/mo")
   fi
 done
-for item in "${EBS_VOLUMES[@]}"; do
+for item in "${MANAGED_DISKS[@]}"; do
   IFS=":" read -r id status cost <<< "$item"
   if [[ $status == "unattached" ]]; then
     RECOMMENDATIONS+=("Delete $id to save \$${cost}/mo")


### PR DESCRIPTION
## Summary
- update scripts to use Azure resource names
- add Azure terminology to README and CLI
- keep existing functionality while focusing on Azure context

## Testing
- `python3 finops_cli.py --help` *(fails: No module named 'rich')*
- `bash check-budgets.sh`
- `bash detect-waste.sh`
- `bash generate-recommendations.sh`


------
https://chatgpt.com/codex/tasks/task_e_6853504c78888323b3ad9431c4d375a4