### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish Python package
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build tools
+        run: |
+          pip install build
+      - name: Build package
+        run: |
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Execute the toolkit in a GitHub Actions runner using the `run-app` workflow.
 Click the badge above, choose **Run workflow**, and once the job completes open
 the run and view the output in the **Summary** tab directly in your browser.
 
+## Build and publish on GitHub
+
+The `publish` workflow builds the Python package and uploads it to PyPI. Push a
+tag like `v1.2.3` or trigger the workflow manually after configuring a
+`PYPI_API_TOKEN` secret in your repository settings.
+
 
 ## Running on Replit or Linux/macOS
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and publish package
- document publish workflow in README

## Testing
- `python3 -m py_compile azure_login.py finops_cli.py finazops/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68535684a05c8323a6346382a6470ad6