### PR TITLE
Add Markdown/HTML export

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Key capabilities include:
 * **Cost trend analysis** – bar charts summarising the last six months across profiles when `--trend` is used.
 * **FinOps audit** – view untagged resources, unused or stopped instances and budget breaches across profiles.
 * **Profile management** – automatic subscription detection, select with `--profiles`, use all with `--all` or combine using `--combine`.
-* **Export options** – set a name with `--report-name` and output to CSV, JSON and/or PDF with `--report-type` (e.g. `--report-type csv json`). Use `--dir` to choose the folder. Trend reports export to JSON only.
+* **Export options** – set a name with `--report-name` and output to CSV, JSON and/or PDF with `--report-type` (e.g. `--report-type csv json`). Use `--dir` to choose the folder. Trend reports export to JSON only. Markdown or HTML reports can be generated with `--export md` or `--export html` (requires the `jinja2` package).
 * **Improved error handling** and a beautiful terminal UI thanks to the Rich library.
 
 Run `./install.sh` (or `install.ps1` on Windows) beforehand so the required Python packages are present.

--- a/finazops/cli.py
+++ b/finazops/cli.py
@@ -4,7 +4,10 @@ import csv
 import json
 from pathlib import Path
 from datetime import datetime, timedelta
-from jinja2 import Template
+try:
+    from jinja2 import Template
+except ImportError:  # pragma: no cover - optional dependency
+    Template = None
 
 try:
     from rich import print
@@ -143,7 +146,11 @@ def export(report, args):
     out_dir = Path(args.dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     if args.export:
-        if args.export == 'md':
+        if Template is None:
+            console.print(
+                "[red]Jinja2 required for Markdown/HTML export. Install jinja2 package.[/red]"
+            )
+        elif args.export == 'md':
             template = Template(MD_TEMPLATE)
             content = template.render(**report)
             path = out_dir / f"{args.report_name}.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "fpdf",
     "azure-identity",
     "azure-mgmt-resource",
+    "jinja2",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ rich
 fpdf
 azure-identity
 azure-mgmt-resource
+jinja2


### PR DESCRIPTION
## Summary
- add optional `--export` flag to `finops_cli.py`
- render Markdown or HTML reports with Jinja2 templates
- include Jinja2 dependency

## Testing
- `pytest -q`
- `python3 -m py_compile finazops/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_6854575287748323be8648a8878bb205