### PR TITLE
Add FastAPI prompt endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,21 @@ Run locally with:
 python3 azure_login.py
 ```
 
+## FastAPI Service
+
+The project also exposes a lightweight FastAPI web server that wraps the CLI.
+Start it with:
+
+```bash
+uvicorn finops_server:app --reload
+```
+
+Send prompts via HTTP:
+
+```bash
+curl -X POST http://localhost:8000/prompt -H "Content-Type: application/json" \
+    -d '{"prompt": "check budget for profile-05"}'
+```
+
+The response includes the command output in JSON format.
+

--- a/finops_server.py
+++ b/finops_server.py
@@ -1,0 +1,49 @@
+from difflib import get_close_matches
+from pathlib import Path
+import subprocess
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+app = FastAPI(title="FinOps CLI API")
+
+BASE_DIR = Path(__file__).resolve().parent
+
+class Prompt(BaseModel):
+    prompt: str
+
+
+def _choose_script(text: str) -> Optional[str]:
+    text = text.lower()
+    if "budget" in text:
+        return "check-budgets.sh"
+    if "waste" in text:
+        return "detect-waste.sh"
+    if "saving" in text or "recommend" in text:
+        return "generate-recommendations.sh"
+
+    keywords = {
+        "budget": "check-budgets.sh",
+        "waste": "detect-waste.sh",
+        "savings": "generate-recommendations.sh",
+    }
+    for word in text.split():
+        match = get_close_matches(word, keywords.keys(), n=1, cutoff=0.8)
+        if match:
+            return keywords[match[0]]
+    return None
+
+
+def handle_prompt(text: str) -> dict:
+    script = _choose_script(text)
+    if not script:
+        raise HTTPException(status_code=400, detail="No matching command found")
+    script_path = BASE_DIR / script
+    result = subprocess.run(["bash", str(script_path)], capture_output=True, text=True)
+    return {"return_code": result.returncode, "output": result.stdout}
+
+
+@app.post("/prompt")
+async def prompt_endpoint(body: Prompt):
+    return handle_prompt(body.prompt)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "azure-identity",
     "azure-mgmt-resource",
     "jinja2",
+    "fastapi",
+    "uvicorn",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ fpdf
 azure-identity
 azure-mgmt-resource
 jinja2
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- expose CLI through a new FastAPI server
- document how to run the HTTP API
- include FastAPI dependencies

## Testing
- `python3 -m py_compile finops_server.py finops_cli.py finazops/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685459518b70832387cc7e9029c4eda2