### PR TITLE
Add init scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@ cd finazops
 
 After the packages are installed you can run the toolkit just like the AWS version but targeting Azure.
 
+## Components
+
+The repository is organised into several parts:
+
+- Shell and PowerShell scripts for common FinOps tasks.
+- A Python CLI available as the `finazops` command.
+- A lightweight FastAPI service for programmatic access.
+- Cross-platform setup scripts `init.sh` and `init.bat` to create a virtual environment and install requirements.
+
 ## Install from PyPI
 
 The CLI can be installed as a package from [PyPI](https://pypi.org/project/finazops/):

--- a/init.bat
+++ b/init.bat
@@ -1,0 +1,23 @@
+@echo off
+REM Initialization helper for the FinOps toolkit
+
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo Python 3 is required but not found.
+    echo Install it from https://www.python.org/downloads/ or the Microsoft Store.
+    exit /b 1
+)
+
+set PYTHON=python
+
+if not exist .venv (
+    echo Creating virtual environment .venv
+    %PYTHON% -m venv .venv
+)
+
+call .venv\Scripts\activate.bat
+
+%PYTHON% -m pip install --upgrade pip >nul
+%PYTHON% -m pip install -r requirements.txt
+
+echo Setup complete.

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Cross-platform initialization helper for the FinOps toolkit
+set -e
+
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+RED="\033[0;31m"
+RESET="\033[0m"
+
+printf "${GREEN}Initializing FinOps toolkit...${RESET}\n"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf "${RED}Python 3 is not installed.${RESET}\n"
+  case "$(uname -s)" in
+    Darwin)
+      printf "${YELLOW}Install it with Homebrew: brew install python@3${RESET}\n";;
+    Linux)
+      printf "${YELLOW}On Ubuntu run: sudo apt install python3 python3-venv${RESET}\n";;
+    *)
+      printf "${YELLOW}Please install Python 3 for your operating system.${RESET}\n";;
+  esac
+  exit 1
+fi
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  printf "${GREEN}Creating virtual environment .venv${RESET}\n"
+  python3 -m venv .venv
+fi
+
+# Activate the environment
+# shellcheck disable=SC1091
+source .venv/bin/activate
+printf "${GREEN}Virtual environment activated${RESET}\n"
+
+# Install requirements
+pip install --upgrade pip >/dev/null
+pip install -r requirements.txt
+printf "${GREEN}Dependencies installed${RESET}\n"


### PR DESCRIPTION
## Summary
- add cross‑platform `init.sh` and `init.bat` for bootstrapping a venv
- update README with a new Components section describing repository pieces

## Testing
- `bash init.sh` *(fails: Could not download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68546c5fb2d8832383e96182b8912dde