### PR TITLE
Improve init scripts and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,19 @@ Clone the repository and install the Python dependencies:
 ```bash
 git clone https://github.com/cloudcwfranck/finazops.git
 cd finazops
-./install.sh
+bash init.sh   # or run init.bat on Windows
 ```
 
 After the packages are installed you can run the toolkit just like the AWS version but targeting Azure.
+
+## Components
+
+The repository is organised into several parts:
+
+- Shell and PowerShell scripts for common FinOps tasks.
+- A Python CLI available as the `finazops` command.
+- A lightweight FastAPI service for programmatic access.
+- Cross-platform setup scripts `init.sh` and `init.bat` to create a virtual environment and install requirements.
 
 ## Install from PyPI
 
@@ -49,7 +58,7 @@ tag like `v1.2.3` or trigger the workflow manually after configuring a
 
 ## Running on Replit or Linux/macOS
 
-After cloning run `./install.sh` once to set up Python packages. Then execute:
+After cloning run `./init.sh` (or `init.bat` on Windows) once to set up the virtual environment and install packages. In new shells activate it with `source .venv/bin/activate` (or `call .venv\Scripts\activate.bat` on Windows). Then execute:
 
 ```bash
 bash detect-waste.sh
@@ -65,10 +74,10 @@ chmod +x *.sh
 
 ## Running on Windows PowerShell
 
-In a PowerShell terminal run the installer once and then execute the scripts:
+In a PowerShell terminal run the setup script once and then execute the scripts:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File install.ps1
+cmd /c init.bat
 ```
 
 Then run:
@@ -99,7 +108,7 @@ Key capabilities include:
 * **Export options** – set a name with `--report-name` and output to CSV, JSON and/or PDF with `--report-type` (e.g. `--report-type csv json`). Use `--dir` to choose the folder. Trend reports export to JSON only. Markdown or HTML reports can be generated with `--export md` or `--export html` (requires the `jinja2` package).
 * **Improved error handling** and a beautiful terminal UI thanks to the Rich library.
 
-Run `./install.sh` (or `install.ps1` on Windows) beforehand so the required Python packages are present.
+Run `./init.sh` (or `init.bat` on Windows) beforehand so the required Python packages are present.
 
 Run the CLI with Python or the installed command:
 
@@ -117,7 +126,7 @@ Exports can be written to CSV, JSON or PDF with `--report-type` and saved to a c
 `azure_login.py` launches an interactive browser window to sign into Azure and
 prints your available subscriptions. It requires the `azure-identity` and
 `azure-mgmt-resource` packages which are installed automatically in the GitHub
-Actions workflow or by running `./install.sh` (or `install.ps1` on Windows).
+Actions workflow or by running `./init.sh` (or `init.bat` on Windows).
 
 Run locally with:
 

--- a/init.bat
+++ b/init.bat
@@ -1,0 +1,24 @@
+@echo off
+REM Initialization helper for the FinOps toolkit
+
+where python >nul 2>nul
+if %ERRORLEVEL% neq 0 (
+    echo Python 3 is required but not found.
+    echo Install it from https://www.python.org/downloads/ or the Microsoft Store.
+    exit /b 1
+)
+
+set PYTHON=python
+
+if not exist .venv (
+    echo Creating virtual environment .venv
+    %PYTHON% -m venv .venv
+)
+
+call .venv\Scripts\activate.bat
+
+%PYTHON% -m pip install --upgrade pip >nul
+%PYTHON% -m pip install -r requirements.txt
+%PYTHON% -m pip install -e . >nul
+
+echo Setup complete. Activate with "call .venv\Scripts\activate.bat".

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Cross-platform initialization helper for the FinOps toolkit
+set -e
+
+GREEN="\033[0;32m"
+YELLOW="\033[1;33m"
+RED="\033[0;31m"
+RESET="\033[0m"
+
+printf "${GREEN}Initializing FinOps toolkit...${RESET}\n"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  printf "${RED}Python 3 is not installed.${RESET}\n"
+  case "$(uname -s)" in
+    Darwin)
+      printf "${YELLOW}Install it with Homebrew: brew install python@3${RESET}\n";;
+    Linux)
+      printf "${YELLOW}On Ubuntu run: sudo apt install python3 python3-venv${RESET}\n";;
+    *)
+      printf "${YELLOW}Please install Python 3 for your operating system.${RESET}\n";;
+  esac
+  exit 1
+fi
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  printf "${GREEN}Creating virtual environment .venv${RESET}\n"
+  python3 -m venv .venv
+fi
+
+# Activate the environment
+# shellcheck disable=SC1091
+source .venv/bin/activate
+printf "${GREEN}Virtual environment activated${RESET}\n"
+
+# Install requirements
+python3 -m pip install --upgrade pip >/dev/null
+python3 -m pip install -r requirements.txt
+python3 -m pip install -e . >/dev/null
+printf "${GREEN}Dependencies installed${RESET}\n"
+
+printf "${GREEN}All set! Run 'source .venv/bin/activate' to use the environment.${RESET}\n"


### PR DESCRIPTION
## Summary
- enhance `init.sh` and `init.bat` to install the package itself and print final activation instructions
- document running `bash init.sh` or `init.bat` for setup
- update usage instructions in README for Linux/macOS, Windows and CLI sections

## Testing
- `bash init.sh >/tmp/init.log && tail -n 5 /tmp/init.log` *(fails: Could not download packages)*


------
https://chatgpt.com/codex/tasks/task_e_68546c5fb2d8832383e96182b8912dde